### PR TITLE
Nested-keys

### DIFF
--- a/common_nb_preprocessors/_nested_dict_updater.py
+++ b/common_nb_preprocessors/_nested_dict_updater.py
@@ -1,0 +1,61 @@
+from collections.abc import Collection, MutableMapping
+from functools import singledispatch
+from typing import Any, Dict, List, Union
+
+
+class NestedDictUpdateError(Exception):
+    """Exception raised for errors while setting a nested dict value."""
+
+
+class NestedDictTypeChangeError(NestedDictUpdateError):
+    """Exception raised if setting of nested dict would change the type."""
+
+
+class NestedDictCollectionOverwriteError(NestedDictUpdateError):
+    """Exception raised if setting value of nested dict would overwrite collection."""
+
+
+class NestedDictInvalidDictError(NestedDictUpdateError):
+    """Exception raised if a dictionary is expected but other type is found during traversal."""
+
+
+@singledispatch
+def _nested_dict_updater_helper(d: object, keys: List[str], _value):
+    raise NestedDictInvalidDictError(
+        f"Expected a dictionary! Won't overwrite entry {d} to set nested keys {keys}"
+    )
+
+
+@_nested_dict_updater_helper.register
+def _(d: MutableMapping, keys: List[str], value):
+    if len(keys) == 1:
+        final_key = keys[0]
+        # should also check for other 'nested' types => always fail
+        # also check if Type changes, if it does, also raise an Exception
+        if final_key in d.keys():
+            if not isinstance(d[final_key], type(value)):
+                raise NestedDictTypeChangeError(
+                    f"Will not overwrite value: {value} of type {type(value)} with {d[final_key]} of type: {type(d[final_key])}"
+                )
+            if isinstance(d[final_key], Collection) and not isinstance(
+                d[final_key], str
+            ):
+                raise NestedDictCollectionOverwriteError(
+                    f"Setting the value of entry '{final_key}' with value {value} would overwrite collection: {d[final_key]}"
+                    + "\n"
+                    + "Overwriting of collections is not allowed, even if the same collection type is used!"
+                )
+        d[keys[0]] = value
+        return
+    d = d.setdefault(keys[0], {})
+    _nested_dict_updater_helper(d, keys[1:], value)
+
+
+def nested_dict_updater(d: Union[Dict, Any], keys: List[str], value: Any) -> None:
+    """**Inplace** nested dictionary updater."""
+    try:
+        _nested_dict_updater_helper(d, keys, value)
+    except NestedDictUpdateError as e:
+        raise NestedDictUpdateError(
+            f"Error while setting nested dict {d} with key-nesting {keys} to value {value}"
+        ) from e

--- a/common_nb_preprocessors/_nested_dict_updater.py
+++ b/common_nb_preprocessors/_nested_dict_updater.py
@@ -20,14 +20,14 @@ class NestedDictInvalidDictError(NestedDictUpdateError):
 
 
 @singledispatch
-def _nested_dict_updater_helper(d: object, keys: List[str], _value):
+def _nested_dict_updater_helper(d: object, keys: List[str], _value) -> None:
     raise NestedDictInvalidDictError(
         f"Expected a dictionary! Won't overwrite entry {d} to set nested keys {keys}"
     )
 
 
 @_nested_dict_updater_helper.register
-def _(d: MutableMapping, keys: List[str], value):
+def _(d: MutableMapping, keys: List[str], value) -> None:
     if len(keys) == 1:
         final_key = keys[0]
         # should also check for other 'nested' types => always fail

--- a/common_nb_preprocessors/_patterns.py
+++ b/common_nb_preprocessors/_patterns.py
@@ -49,23 +49,27 @@ def build_prefixed_regex_pattern_with_value(
     prefix: str = Field(..., min_length=1),
     key_term: str = Field(..., min_length=1),
     delimiter: str = Field("=", min_length=1),
+    expand_key_term: bool = False,
 ) -> Pattern[str]:
     """
     A regular expression builder that returns a compiled
     regular expression that matches a string with:
     - The (escaped) `prefix` string (may have whitespaces before or after)
-    - The (escaped) `key_term` to capture with the group name `key` is
+    - The (escaped) `key_term` to capture with the group name `key`
+        - If `expand_key_term` is set, the `key_term` will be seen as a *key-prefix*
+            and the matched key will be lazily expanded.
     - Followed by an (escaped) `delimiter` (may have whitespaces before or after)
     - and captures the following line until the end of the line with the group name `value`
     """
     prefix = re.escape(prefix)
     key_term = re.escape(key_term)
     delimiter = re.escape(delimiter)
+    key_expansion_suffix = ".*?" if expand_key_term else ""
     pattern = re.compile(
         rf"""
         ^ # match start of each line
         \s*{prefix}\s* # allow whitespace before and after prefix
-        (?P<key>{key_term}) # term to capture
+        (?P<key>{key_term}{key_expansion_suffix}) # term to capture
         \s*{delimiter}\s* # allow whitespace before and after delimiter
         (?P<value>[^\n\r]+)
         $ # match end of each line (excludes \n in MULTILINE)

--- a/common_nb_preprocessors/myst_nb.py
+++ b/common_nb_preprocessors/myst_nb.py
@@ -245,6 +245,7 @@ def myst_nb_metadata_injector(
         remove_line=remove_line,
         delimiter=delimiter,
         value_to_yaml=True,
+        allow_nested_keys=True,
     ).preprocess(nb, None)
     return nb
 

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -143,6 +143,7 @@
     "The other configuration method is to _set_ key-value pairs inside of the `mystnb` metadata tag of the code-cell.\n",
     "See [](sec/mystnb-conf) for details.\n",
     "Note that the things you can configure are _mostly_ different between both of these methods! You should take a look at _both_!\n",
+    "I've also spend quite a lot of time to create some _syntax_ sugar for settings nested key-value pairs. See [](sec/syntax_sugar) for more details.\n",
     "\n",
     "If the last paragraph confused you, don't worry.\n",
     "It is probably not that important for you as it discusses the _conceptual_ difference between the two configuration options.\n",
@@ -980,13 +981,77 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "(sec/syntax_sugar)=\n",
+    "## Syntax Sugar\n",
+    "\n",
+    "I've spent _way too much time_ (and made the library significantly complexer) to allow nested key setting.\n",
+    "This is especially useful for nested options such as [](sec/figure) and [](sec/image).\n",
+    "So instead of writing a long line like the following:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Source:\n",
+    "\n",
+    "```python\n",
+    "# figure = {\"caption\": \"I am a top caption!\", \"caption_before\": true}\n",
+    "# image = {\"width\": \"10%\", \"alt\": \"Fish with party hat\"}\n",
+    "from IPython.display import Image\n",
+    "Image(\"fish.png\")\n",
+    "```"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# figure = {\"caption\": \"I am a top caption!\", \"caption_before\": true}\n",
+    "# image = {\"width\": \"10%\", \"alt\": \"Fish with party hat\"}\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(\"fish.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You could also write it in such a way that each option is on their own line and access the next _level_ with using the dot (`.`) character.\n",
+    "\n",
+    "```python\n",
+    "# figure.caption = \"I am a top caption!\"\n",
+    "# figure.caption_before = true\n",
+    "# image.width = \"10%\"\n",
+    "# image.alt = \"Fish with party hat\"\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(\"fish.png\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# figure.caption = \"I am a top caption!\"\n",
+    "# figure.caption_before = true\n",
+    "# image.width = \"10%\"\n",
+    "# image.alt = \"Fish with party hat\"\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(\"fish.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],

--- a/tests/test_metadata_injector.py
+++ b/tests/test_metadata_injector.py
@@ -1,13 +1,76 @@
-from typing import Dict
-
 import nbformat
 import pytest
-from traitlets import TraitError
 
 from common_nb_preprocessors.metadata_injector import (
     MetaDataListInjectorPreprocessor,
     MetaDataMapInjectorPreprocessor,
+    _nested_dict_updater,
+    _nested_dict_updater_helper,
 )
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value,out_dict",
+    [
+        ({}, ["a"], 1, {"a": 1}),
+        ({}, ["a"], "1", {"a": "1"}),
+        ({}, ["a", "b"], 1, {"a": {"b": 1}}),
+        ({}, ["a", "b", "c"], 1, {"a": {"b": {"c": 1}}}),
+        ({"a": 1}, ["a"], 2, {"a": 2}),
+        ({"a": {"b": {"c": "z"}}}, ["a", "b", "c"], "1", {"a": {"b": {"c": "1"}}}),
+        ({"a": 1}, ["b"], 2, {"a": 1, "b": 2}),
+        (
+            {"a": {"b": 1, "c": 2}, "d": 3},
+            ["a", "b"],
+            9,
+            {"a": {"b": 9, "c": 2}, "d": 3},
+        ),
+    ],
+)
+def test_nested_dict_updater_helper(inp_dict, keys, value, out_dict):
+    # works in-place!
+    _nested_dict_updater_helper(inp_dict, keys, value)
+    assert inp_dict == out_dict
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys",
+    [
+        (["not_dict"], ["a"]),
+        ({"a": 1}, ["a", "b"]),
+        ({"a": {"b": 1}}, ["a", "b", "c"]),
+    ],
+)
+def test_nested_dict_updater_helper_invalid_nesting(inp_dict, keys):
+    with pytest.raises(RuntimeError, match="Won't overwrite .* to set nested key"):
+        _nested_dict_updater_helper(inp_dict.copy(), keys, {"b": 1})
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value",
+    [
+        ({"a": {"b": 1}}, ["a"], 1),
+        ({"a": {"b": 1}}, ["a", "b"], "1"),
+        ({"a": {"b": 1}}, ["a", "b"], [1]),
+    ],
+)
+def test_nested_dict_updater_helper_invalid_type_setting(inp_dict, keys, value):
+    with pytest.raises(TypeError, match="Will not overwrite"):
+        _nested_dict_updater_helper(inp_dict.copy(), keys, value)
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value",
+    [
+        ({"a": {"b": 1}}, ["a"], {"b": 2, "c": 1}),
+        ({"a": {"b": 1}}, ["a"], {"b": 1}),
+        ({"a": [1]}, ["a"], [2]),
+        ({"a": {1}}, ["a"], {2}),
+    ],
+)
+def test_nested_dict_updater_helper_invalid_collection_setting(inp_dict, keys, value):
+    with pytest.raises(RuntimeError, match="would overwrite collection"):
+        _nested_dict_updater_helper(inp_dict.copy(), keys, value)
 
 
 def test_metadata_injector():
@@ -167,7 +230,7 @@ def test_metadata_map_type_clash():
     nb.cells.append(
         nbformat.v4.new_code_cell("# a=false", metadata={"mystnb": "single-value"})
     )
-    with pytest.raises(RuntimeError, match="type"):
+    with pytest.raises(RuntimeError, match="Expected a dictionary!"):
         nb, _ = MetaDataMapInjectorPreprocessor(
             keys=["a"], metadata_group="mystnb"
         ).preprocess(nb, None)

--- a/tests/test_mystnb.py
+++ b/tests/test_mystnb.py
@@ -44,3 +44,26 @@ def test_myst_nb_metadata_injector(prefix: str, remove_line: bool, delimiter: st
         assert len_source_lines == 2
     else:
         assert len_source_lines == 4
+
+
+def test_myst_nb_metadata_injector_syntax_sugar():
+    nb = nbformat.v4.new_notebook()
+    src = f"""\
+        # figure.caption = I am a string
+        # figure.caption_before = true
+        other code line\
+    """
+    nb.cells.append(nbformat.v4.new_code_cell(src))
+    new_nb = myst_nb_metadata_injector(
+        nbformat.writes(nb),
+        prefix="#",
+        delimiter="=",
+        remove_line=True,
+    )
+    assert new_nb.cells[0].hasattr("metadata")
+    assert new_nb.cells[0].metadata.hasattr("mystnb")
+    assert new_nb.cells[0].metadata.mystnb == {
+        "figure": {"caption": "I am a string", "caption_before": True}
+    }
+    len_source_lines = len(new_nb.cells[0].source.splitlines())
+    assert len_source_lines == 1

--- a/tests/test_nested_dict_updater.py
+++ b/tests/test_nested_dict_updater.py
@@ -1,0 +1,76 @@
+import pytest
+
+from common_nb_preprocessors._nested_dict_updater import (
+    NestedDictCollectionOverwriteError,
+    NestedDictInvalidDictError,
+    NestedDictTypeChangeError,
+    NestedDictUpdateError,
+    nested_dict_updater,
+)
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value,out_dict",
+    [
+        ({}, ["a"], 1, {"a": 1}),
+        ({}, ["a"], "1", {"a": "1"}),
+        ({}, ["a", "b"], 1, {"a": {"b": 1}}),
+        ({}, ["a", "b", "c"], 1, {"a": {"b": {"c": 1}}}),
+        ({"a": 1}, ["a"], 2, {"a": 2}),
+        ({"a": {"b": {"c": "z"}}}, ["a", "b", "c"], "1", {"a": {"b": {"c": "1"}}}),
+        ({"a": 1}, ["b"], 2, {"a": 1, "b": 2}),
+        (
+            {"a": {"b": 1, "c": 2}, "d": 3},
+            ["a", "b"],
+            9,
+            {"a": {"b": 9, "c": 2}, "d": 3},
+        ),
+    ],
+)
+def testnested_dict_updater(inp_dict, keys, value, out_dict):
+    # works in-place!
+    nested_dict_updater(inp_dict, keys, value)
+    assert inp_dict == out_dict
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys",
+    [
+        (["not_dict"], ["a"]),
+        ({"a": 1}, ["a", "b"]),
+        ({"a": {"b": 1}}, ["a", "b", "c"]),
+    ],
+)
+def testnested_dict_updater_invalid_nesting(inp_dict, keys):
+    with pytest.raises(NestedDictUpdateError) as exc_info:
+        nested_dict_updater(inp_dict.copy(), keys, {"b": 1})
+    assert type(exc_info.value.__cause__) == NestedDictInvalidDictError
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value",
+    [
+        ({"a": {"b": 1}}, ["a"], 1),
+        ({"a": {"b": 1}}, ["a", "b"], "1"),
+        ({"a": {"b": 1}}, ["a", "b"], [1]),
+    ],
+)
+def testnested_dict_updater_invalid_type_setting(inp_dict, keys, value):
+    with pytest.raises(NestedDictUpdateError) as exc_info:
+        nested_dict_updater(inp_dict.copy(), keys, value)
+    assert type(exc_info.value.__cause__) is NestedDictTypeChangeError
+
+
+@pytest.mark.parametrize(
+    "inp_dict,keys,value",
+    [
+        ({"a": {"b": 1}}, ["a"], {"b": 2, "c": 1}),
+        ({"a": {"b": 1}}, ["a"], {"b": 1}),
+        ({"a": [1]}, ["a"], [2]),
+        ({"a": {1}}, ["a"], {2}),
+    ],
+)
+def testnested_dict_updater_invalid_collection_setting(inp_dict, keys, value):
+    with pytest.raises(NestedDictUpdateError) as exc_info:
+        nested_dict_updater(inp_dict.copy(), keys, value)
+    assert type(exc_info.value.__cause__) is NestedDictCollectionOverwriteError

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -102,6 +102,32 @@ def test_pattern_with_value_delimiter_handling(delimiter, text):
     assert "true" == pattern.search(text).group("value")
 
 
+# If I am bored, I could rewrite these with hypothesis
+@pytest.mark.parametrize("delimiter", ["="])
+# hide will always be key_term!
+@pytest.mark.parametrize(
+    "inp_key_text,matched_key",
+    [
+        ("hide", "hide"),
+        ("hide ", "hide"),
+        ("hide.", "hide."),
+        ("hide. ", "hide."),
+        ("hide.two", "hide.two"),
+        ("hide.two ", "hide.two"),
+    ],
+)
+def test_pattern_with_value_key_expansion(delimiter, inp_key_text, matched_key):
+    prefix = "#"
+    key = "hide"
+    value = "true"
+    text = f"{prefix} {inp_key_text}{delimiter}{value}"
+    pattern = build_prefixed_regex_pattern_with_value(
+        prefix=prefix, key_term=key, delimiter=delimiter, expand_key_term=True
+    )
+    assert matched_key == pattern.search(text).group("key")
+    assert "true" == pattern.search(text).group("value")
+
+
 @pytest.mark.parametrize(
     "invalid_kwargs", [{"prefix": ""}, {"key_term": ""}, {"delimiter": ""}]
 )


### PR DESCRIPTION
The current solution is as follows:
- The regex pattern with value builder now has an option that allows the key to lazily "grow"
- The key group is now NOT identical to the input key_term!
- The matched key will then be used by the map preprocessor to retrieve the subkeys (if wanted) by splitting the matched key by the dot character.
- Fixed a bug where only the first match object was processed. Now all of them are processed and multiple calls will overwrite each other.
- Added tests to verify the correctness of the nested key parsing and yaml conversion for the metadata_injector functions
- Added required tests for those
- Updated the documentation to document the behavior